### PR TITLE
Implement new machine selection flow and button style

### DIFF
--- a/app/src/main/java/com/example/mocomp/MainMenuActivity.java
+++ b/app/src/main/java/com/example/mocomp/MainMenuActivity.java
@@ -18,7 +18,7 @@ public class MainMenuActivity extends AppCompatActivity {
         Button exitButton = findViewById(R.id.button_exit);
 
         selectButton.setOnClickListener(v ->
-                startActivity(new Intent(MainMenuActivity.this, SelectMachineActivity.class)));
+                startActivity(new Intent(MainMenuActivity.this, ScanQRActivity.class)));
 
         statsButton.setOnClickListener(v ->
                 startActivity(new Intent(MainMenuActivity.this, FactoryStatsActivity.class)));

--- a/app/src/main/java/com/example/mocomp/ScanQRActivity.java
+++ b/app/src/main/java/com/example/mocomp/ScanQRActivity.java
@@ -15,10 +15,8 @@ public class ScanQRActivity extends AppCompatActivity {
         Button simulate = findViewById(R.id.button_simulate_scan);
         Button manual = findViewById(R.id.button_manual_entry);
 
-        simulate.setOnClickListener(v -> {
-            startActivity(new Intent(ScanQRActivity.this, MachineInfoActivity.class));
-            finish();
-        });
+        simulate.setOnClickListener(v ->
+                startActivity(new Intent(ScanQRActivity.this, SelectMachineActivity.class)));
 
         manual.setOnClickListener(v ->
                 startActivity(new Intent(ScanQRActivity.this, SelectMachineActivity.class)));

--- a/app/src/main/res/layout/activity_factory_stats.xml
+++ b/app/src/main/res/layout/activity_factory_stats.xml
@@ -15,11 +15,8 @@
 
     <Button
         android:id="@+id/button_back_menu"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/DefaultButton"
         android:layout_marginTop="16dp"
-        android:text="Back"
-        android:textColor="@color/white"
-        android:backgroundTint="@color/accent" />
+        android:text="Back" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -10,11 +10,8 @@
 
     <Button
         android:id="@+id/button_login"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/DefaultButton"
         android:text="Login"
-        android:textColor="@color/white"
-        android:backgroundTint="@color/accent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/activity_machine_info.xml
+++ b/app/src/main/res/layout/activity_machine_info.xml
@@ -16,29 +16,20 @@
 
     <Button
         android:id="@+id/button_back_main"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/DefaultButton"
         android:layout_marginTop="16dp"
-        android:text="Menu"
-        android:textColor="@color/white"
-        android:backgroundTint="@color/accent" />
+        android:text="Menu" />
 
     <Button
         android:id="@+id/button_monitor"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/DefaultButton"
         android:layout_marginTop="16dp"
-        android:text="Monitor"
-        android:textColor="@color/white"
-        android:backgroundTint="@color/accent" />
+        android:text="Monitor" />
 
     <Button
         android:id="@+id/button_maintenance"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/DefaultButton"
         android:layout_marginTop="16dp"
-        android:text="Maintenance"
-        android:textColor="@color/white"
-        android:backgroundTint="@color/accent" />
+        android:text="Maintenance" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main_menu.xml
+++ b/app/src/main/res/layout/activity_main_menu.xml
@@ -9,28 +9,19 @@
 
     <Button
         android:id="@+id/button_select_machine"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Select Machine"
-        android:textColor="@color/white"
-        android:backgroundTint="@color/accent" />
+        style="@style/DefaultButton"
+        android:text="Select Machine" />
 
     <Button
         android:id="@+id/button_show_stats"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/DefaultButton"
         android:text="Show Statistics"
-        android:textColor="@color/white"
-        android:backgroundTint="@color/accent"
         android:layout_marginTop="16dp" />
 
     <Button
         android:id="@+id/button_exit"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/DefaultButton"
         android:text="Exit"
-        android:textColor="@color/white"
-        android:backgroundTint="@color/accent"
         android:layout_marginTop="16dp" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_maintenance.xml
+++ b/app/src/main/res/layout/activity_maintenance.xml
@@ -15,10 +15,7 @@
 
     <Button
         android:id="@+id/button_back_info"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/DefaultButton"
         android:layout_marginTop="16dp"
-        android:text="Back"
-        android:textColor="@color/white"
-        android:backgroundTint="@color/accent" />
+        android:text="Back" />
 </LinearLayout>

--- a/app/src/main/res/layout/activity_monitoring.xml
+++ b/app/src/main/res/layout/activity_monitoring.xml
@@ -15,10 +15,7 @@
 
     <Button
         android:id="@+id/button_back_info"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/DefaultButton"
         android:layout_marginTop="16dp"
-        android:text="Back"
-        android:textColor="@color/white"
-        android:backgroundTint="@color/accent" />
+        android:text="Back" />
 </LinearLayout>

--- a/app/src/main/res/layout/activity_scan_qr.xml
+++ b/app/src/main/res/layout/activity_scan_qr.xml
@@ -15,20 +15,14 @@
 
     <Button
         android:id="@+id/button_simulate_scan"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/DefaultButton"
         android:layout_marginTop="16dp"
-        android:text="Simulate Scan"
-        android:textColor="@color/white"
-        android:backgroundTint="@color/accent" />
+        android:text="Simulate Scan" />
 
     <Button
         android:id="@+id/button_manual_entry"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/DefaultButton"
         android:layout_marginTop="16dp"
-        android:text="Enter Machine ID"
-        android:textColor="@color/white"
-        android:backgroundTint="@color/accent" />
+        android:text="Enter Machine ID" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_select_machine.xml
+++ b/app/src/main/res/layout/activity_select_machine.xml
@@ -15,11 +15,8 @@
 
     <Button
         android:id="@+id/button_confirm"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        style="@style/DefaultButton"
         android:layout_marginTop="16dp"
-        android:text="Confirm"
-        android:textColor="@color/white"
-        android:backgroundTint="@color/accent" />
+        android:text="Confirm" />
 
 </LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="DefaultButton">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:textColor">@color/white</item>
+        <item name="android:backgroundTint">@color/accent</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Summary
- add `DefaultButton` style and apply to all buttons for consistent design
- change navigation: Main menu opens QR scanner, and QR actions lead to manual ID entry

## Testing
- `./gradlew help`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a4597938832da72ec2cc2f6b2bf1