### PR TITLE
Add login data transfer and factory stats chart

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
     implementation(libs.material)
     implementation(libs.activity)
     implementation(libs.constraintlayout)
+    implementation(libs.mpandroidchart)
+    implementation(libs.zxing.embedded)
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/mocomp/ConditionStorage.java
+++ b/app/src/main/java/com/example/mocomp/ConditionStorage.java
@@ -1,0 +1,19 @@
+package com.example.mocomp;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+public class ConditionStorage {
+    private static final String PREFS = "conditions";
+
+    public static void increment(Context context, String status) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+        int current = prefs.getInt(status, 0);
+        prefs.edit().putInt(status, current + 1).apply();
+    }
+
+    public static int get(Context context, String status) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+        return prefs.getInt(status, 0);
+    }
+}

--- a/app/src/main/java/com/example/mocomp/FactoryStatsActivity.java
+++ b/app/src/main/java/com/example/mocomp/FactoryStatsActivity.java
@@ -3,6 +3,17 @@ package com.example.mocomp;
 import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Button;
+import com.github.mikephil.charting.charts.BarChart;
+import com.github.mikephil.charting.components.XAxis;
+import com.github.mikephil.charting.data.BarData;
+import com.github.mikephil.charting.data.BarDataSet;
+import com.github.mikephil.charting.data.BarEntry;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -12,10 +23,61 @@ public class FactoryStatsActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_factory_stats);
 
+        BarChart chart = findViewById(R.id.bar_chart);
+        fetchRemoteData(() -> updateChart(chart));
+        updateChart(chart);
+
         Button back = findViewById(R.id.button_back_menu);
         back.setOnClickListener(v -> {
             startActivity(new Intent(FactoryStatsActivity.this, MainMenuActivity.class));
             finish();
         });
+    }
+
+    private void fetchRemoteData(Runnable onComplete) {
+        new Thread(() -> {
+            try {
+                URL url = new URL("https://example.com/posts.json");
+                HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+                StringBuilder sb = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) sb.append(line);
+                reader.close();
+
+                JSONObject obj = new JSONObject(sb.toString());
+                JSONArray posts = obj.getJSONArray("posts");
+                for (int i = 0; i < posts.length(); i++) {
+                    JSONObject p = posts.getJSONObject(i);
+                    String value = p.getString("value");
+                    ConditionStorage.increment(FactoryStatsActivity.this, value);
+                }
+            } catch (Exception ignored) {
+            }
+            runOnUiThread(onComplete);
+        }).start();
+    }
+
+    private void updateChart(BarChart chart) {
+        int running = ConditionStorage.get(this, "running");
+        int stopped = ConditionStorage.get(this, "stopped");
+        int error = ConditionStorage.get(this, "error");
+
+        BarDataSet set = new BarDataSet(java.util.Arrays.asList(
+                new BarEntry(0, running),
+                new BarEntry(1, stopped),
+                new BarEntry(2, error)
+        ), "Machine States");
+        BarData data = new BarData(set);
+        chart.setData(data);
+        XAxis xAxis = chart.getXAxis();
+        xAxis.setValueFormatter((value, axis) -> {
+            switch ((int) value) {
+                case 0: return "running";
+                case 1: return "stopped";
+                default: return "error";
+            }
+        });
+        chart.invalidate();
     }
 }

--- a/app/src/main/java/com/example/mocomp/LoginActivity.java
+++ b/app/src/main/java/com/example/mocomp/LoginActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 import android.content.Intent;
 import android.widget.Button;
+import android.widget.EditText;
 
 public class LoginActivity extends AppCompatActivity {
 
@@ -13,8 +14,16 @@ public class LoginActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_login);
 
+        EditText username = findViewById(R.id.edit_username);
+        EditText password = findViewById(R.id.edit_password);
         Button login = findViewById(R.id.button_login);
-        login.setOnClickListener(v ->
-                startActivity(new Intent(LoginActivity.this, MainMenuActivity.class)));
+        login.setOnClickListener(v -> {
+            String name = username.getText().toString();
+            // Password is ignored in this demo
+            UserProfile profile = new UserProfile(name, "Techniker", 100);
+            Intent intent = new Intent(LoginActivity.this, MainMenuActivity.class);
+            intent.putExtra("user", profile);
+            startActivity(intent);
+        });
     }
 }

--- a/app/src/main/java/com/example/mocomp/MainMenuActivity.java
+++ b/app/src/main/java/com/example/mocomp/MainMenuActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
+import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -12,7 +13,14 @@ public class MainMenuActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main_menu);
-        
+
+        UserProfile profile = (UserProfile) getIntent().getSerializableExtra("user");
+        TextView header = findViewById(R.id.text_header);
+        if (profile != null) {
+            String text = profile.getUsername() + " (" + profile.getRole() + ", " + profile.getEmploymentPercent() + "% )";
+            header.setText(text);
+        }
+
         Button selectButton = findViewById(R.id.button_select_machine);
         Button statsButton = findViewById(R.id.button_show_stats);
         Button exitButton = findViewById(R.id.button_exit);

--- a/app/src/main/java/com/example/mocomp/MaintenanceActivity.java
+++ b/app/src/main/java/com/example/mocomp/MaintenanceActivity.java
@@ -11,6 +11,7 @@ public class MaintenanceActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_maintenance);
+        ConditionStorage.increment(this, "stopped");
 
         Button back = findViewById(R.id.button_back_info);
         back.setOnClickListener(v -> {

--- a/app/src/main/java/com/example/mocomp/MonitoringActivity.java
+++ b/app/src/main/java/com/example/mocomp/MonitoringActivity.java
@@ -11,6 +11,7 @@ public class MonitoringActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_monitoring);
+        ConditionStorage.increment(this, "running");
 
         Button back = findViewById(R.id.button_back_info);
         back.setOnClickListener(v -> {

--- a/app/src/main/java/com/example/mocomp/ScanQRActivity.java
+++ b/app/src/main/java/com/example/mocomp/ScanQRActivity.java
@@ -4,6 +4,9 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Button;
 
+import com.journeyapps.barcodescanner.ScanContract;
+import com.journeyapps.barcodescanner.ScanOptions;
+
 import androidx.appcompat.app.AppCompatActivity;
 
 public class ScanQRActivity extends AppCompatActivity {
@@ -14,11 +17,24 @@ public class ScanQRActivity extends AppCompatActivity {
 
         Button simulate = findViewById(R.id.button_simulate_scan);
         Button manual = findViewById(R.id.button_manual_entry);
+        simulate.setOnClickListener(v -> startScan());
 
-        simulate.setOnClickListener(v ->
-                startActivity(new Intent(ScanQRActivity.this, SelectMachineActivity.class)));
+        manual.setOnClickListener(v -> {
+            ConditionStorage.increment(ScanQRActivity.this, "error");
+            startActivity(new Intent(ScanQRActivity.this, SelectMachineActivity.class));
+        });
+    }
 
-        manual.setOnClickListener(v ->
-                startActivity(new Intent(ScanQRActivity.this, SelectMachineActivity.class)));
+    private final androidx.activity.result.ActivityResultLauncher<ScanOptions> scanLauncher = registerForActivityResult(new ScanContract(), result -> {
+        if (result.getContents() != null) {
+            startActivity(new Intent(ScanQRActivity.this, SelectMachineActivity.class));
+        }
+    });
+
+    private void startScan() {
+        ScanOptions options = new ScanOptions();
+        options.setDesiredBarcodeFormats(ScanOptions.QR_CODE);
+        options.setPrompt("Scan QR Code");
+        scanLauncher.launch(options);
     }
 }

--- a/app/src/main/java/com/example/mocomp/SelectMachineActivity.java
+++ b/app/src/main/java/com/example/mocomp/SelectMachineActivity.java
@@ -14,6 +14,7 @@ public class SelectMachineActivity extends AppCompatActivity {
 
         Button confirm = findViewById(R.id.button_confirm);
         confirm.setOnClickListener(v -> {
+            ConditionStorage.increment(this, "running");
             startActivity(new Intent(SelectMachineActivity.this, MachineInfoActivity.class));
             finish();
         });

--- a/app/src/main/java/com/example/mocomp/UserProfile.java
+++ b/app/src/main/java/com/example/mocomp/UserProfile.java
@@ -1,0 +1,27 @@
+package com.example.mocomp;
+
+import java.io.Serializable;
+
+public class UserProfile implements Serializable {
+    private String username;
+    private String role;
+    private int employmentPercent;
+
+    public UserProfile(String username, String role, int employmentPercent) {
+        this.username = username;
+        this.role = role;
+        this.employmentPercent = employmentPercent;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public int getEmploymentPercent() {
+        return employmentPercent;
+    }
+}

--- a/app/src/main/res/layout/activity_factory_stats.xml
+++ b/app/src/main/res/layout/activity_factory_stats.xml
@@ -13,6 +13,12 @@
         android:text="Factory Statistics"
         android:textColor="@color/white" />
 
+    <com.github.mikephil.charting.charts.BarChart
+        android:id="@+id/bar_chart"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:layout_marginTop="16dp" />
+
     <Button
         android:id="@+id/button_back_menu"
         style="@style/DefaultButton"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -8,13 +8,35 @@
     android:background="@color/dark_background"
     tools:context=".LoginActivity">
 
+    <EditText
+        android:id="@+id/edit_username"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:hint="Username"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <EditText
+        android:id="@+id/edit_password"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:hint="Password"
+        android:inputType="textPassword"
+        app:layout_constraintTop_toBottomOf="@id/edit_username"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <Button
         android:id="@+id/button_login"
         style="@style/DefaultButton"
         android:text="Login"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/edit_password"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main_menu.xml
+++ b/app/src/main/res/layout/activity_main_menu.xml
@@ -7,6 +7,14 @@
     android:background="@color/dark_background"
     android:padding="16dp">
 
+    <TextView
+        android:id="@+id/text_header"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/white"
+        android:textSize="18sp"
+        android:layout_marginBottom="16dp" />
+
     <Button
         android:id="@+id/button_select_machine"
         style="@style/DefaultButton"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ appcompat = "1.7.1"
 material = "1.12.0"
 activity = "1.10.1"
 constraintlayout = "2.2.1"
+mpandroidchart = "3.1.0"
+zxing = "4.3.0"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -16,6 +18,8 @@ appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "a
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+mpandroidchart = { group = "com.github.PhilJay", name = "mpandroidchart", version.ref = "mpandroidchart" }
+zxing-embedded = { group = "com.journeyapps", name = "zxing-android-embedded", version.ref = "zxing" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- handle user credentials using `UserProfile`
- pass the profile via `Intent`
- display login info in `MainMenuActivity`
- record machine states in shared preferences
- show statistics in `FactoryStatsActivity` using `MPAndroidChart`
- integrate QR code scanning and recording errors
- add dependencies for MPAndroidChart and ZXing

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a93fa294832da18cb41b50c38ea6