### PR TITLE
Center login fields and use white text

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -15,9 +15,11 @@
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
         android:hint="Username"
+        android:textColor="@color/white"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintVertical_chainStyle="packed" />
 
     <EditText
         android:id="@+id/edit_password"
@@ -27,6 +29,7 @@
         android:layout_marginEnd="16dp"
         android:hint="Password"
         android:inputType="textPassword"
+        android:textColor="@color/white"
         app:layout_constraintTop_toBottomOf="@id/edit_username"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
@@ -37,6 +40,7 @@
         android:text="Login"
         app:layout_constraintTop_toBottomOf="@id/edit_password"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- center login EditText fields and button using a packed vertical chain
- ensure username and password text is white for dark background

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685567cf4cec832db2d899e4cd9aa9b3