### PR TITLE
Add uniform text styles and screen headers

### DIFF
--- a/app/src/main/res/layout/activity_factory_stats.xml
+++ b/app/src/main/res/layout/activity_factory_stats.xml
@@ -10,8 +10,8 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Factory Statistics"
-        android:textColor="@color/white" />
+        style="@style/HeaderText"
+        android:text="Factory Statistics" />
 
     <com.github.mikephil.charting.charts.BarChart
         android:id="@+id/bar_chart"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -8,6 +8,17 @@
     android:background="@color/dark_background"
     tools:context=".LoginActivity">
 
+    <TextView
+        android:id="@+id/text_screen_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        style="@style/HeaderText"
+        android:text="Login"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginTop="32dp" />
+
     <EditText
         android:id="@+id/edit_username"
         android:layout_width="0dp"
@@ -16,7 +27,7 @@
         android:layout_marginTop="340dp"
         android:layout_marginEnd="16dp"
         android:hint="Username"
-        android:textColor="@color/white"
+        style="@style/DefaultText"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
@@ -32,7 +43,7 @@
         android:layout_marginEnd="16dp"
         android:hint="Password"
         android:inputType="textPassword"
-        android:textColor="@color/white"
+        style="@style/DefaultText"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/activity_machine_info.xml
+++ b/app/src/main/res/layout/activity_machine_info.xml
@@ -8,11 +8,17 @@
     android:padding="16dp">
 
     <TextView
+        android:id="@+id/text_screen_info"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Machine ID: 12345\nStatus: Running"
-        android:textColor="@color/white"
-        android:textSize="18sp" />
+        style="@style/HeaderText"
+        android:text="Machine Info" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        style="@style/DefaultText"
+        android:text="Machine ID: 12345\nStatus: Running" />
 
     <Button
         android:id="@+id/button_back_main"

--- a/app/src/main/res/layout/activity_main_menu.xml
+++ b/app/src/main/res/layout/activity_main_menu.xml
@@ -8,11 +8,17 @@
     android:padding="16dp">
 
     <TextView
+        android:id="@+id/text_screen_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        style="@style/HeaderText"
+        android:text="Main Menu" />
+
+    <TextView
         android:id="@+id/text_header"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textColor="@color/white"
-        android:textSize="18sp"
+        style="@style/DefaultText"
         android:layout_marginBottom="16dp" />
 
     <Button

--- a/app/src/main/res/layout/activity_maintenance.xml
+++ b/app/src/main/res/layout/activity_maintenance.xml
@@ -10,8 +10,8 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Maintenance Tasks"
-        android:textColor="@color/white" />
+        style="@style/HeaderText"
+        android:text="Maintenance Tasks" />
 
     <Button
         android:id="@+id/button_back_info"

--- a/app/src/main/res/layout/activity_monitoring.xml
+++ b/app/src/main/res/layout/activity_monitoring.xml
@@ -10,8 +10,8 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Monitoring Data"
-        android:textColor="@color/white" />
+        style="@style/HeaderText"
+        android:text="Monitoring Data" />
 
     <Button
         android:id="@+id/button_back_info"

--- a/app/src/main/res/layout/activity_scan_qr.xml
+++ b/app/src/main/res/layout/activity_scan_qr.xml
@@ -10,8 +10,8 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Scan QR Code"
-        android:textColor="@color/white" />
+        style="@style/HeaderText"
+        android:text="Scan QR Code" />
 
     <Button
         android:id="@+id/button_simulate_scan"

--- a/app/src/main/res/layout/activity_select_machine.xml
+++ b/app/src/main/res/layout/activity_select_machine.xml
@@ -7,11 +7,19 @@
     android:background="@color/dark_background"
     android:padding="16dp">
 
+    <TextView
+        android:id="@+id/text_screen_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        style="@style/HeaderText"
+        android:text="Select Machine" />
+
     <EditText
         android:id="@+id/edit_machine_id"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="Machine ID" />
+        android:hint="Machine ID"
+        style="@style/DefaultText" />
 
     <Button
         android:id="@+id/button_confirm"

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -3,5 +3,7 @@
     <style name="Base.Theme.MoComp" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your dark theme here. -->
         <!-- <item name="colorPrimary">@color/my_dark_primary</item> -->
+        <item name="android:textColor">@color/white</item>
+        <item name="android:fontFamily">sans-serif</item>
     </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,4 +6,15 @@
         <item name="android:textColor">@color/white</item>
         <item name="android:backgroundTint">@color/accent</item>
     </style>
+
+    <style name="DefaultText">
+        <item name="android:textColor">@color/white</item>
+        <item name="android:fontFamily">sans-serif</item>
+        <item name="android:textSize">16sp</item>
+    </style>
+
+    <style name="HeaderText" parent="DefaultText">
+        <item name="android:textSize">20sp</item>
+        <item name="android:textStyle">bold</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,6 +3,8 @@
     <style name="Base.Theme.MoComp" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your light theme here. -->
         <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
+        <item name="android:textColor">@color/white</item>
+        <item name="android:fontFamily">sans-serif</item>
     </style>
 
     <style name="Theme.MoComp" parent="Base.Theme.MoComp" />


### PR DESCRIPTION
## Summary
- introduce DefaultText and HeaderText styles
- add screen info headers to every view
- update existing layouts to use the new styles
- set text color and font in app themes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556cb64a58832daaef9caa668c2a8f